### PR TITLE
Make civil.Date zero value valid

### DIFF
--- a/civil.go
+++ b/civil.go
@@ -51,10 +51,10 @@ func DateOf(t time.Time) Date {
 // RFC3339Date is the civil date format of RFC3339
 const RFC3339Date = "2006-01-02"
 
-const dateZero = "0000-00-00"
-
 // ParseDate parses a string in RFC3339 full-date format and returns the date value it represents.
 func ParseDate(s string) (Date, error) {
+	const dateZero = "0000-00-00"
+
 	if s == dateZero {
 		return Date{}, nil
 	}
@@ -420,11 +420,6 @@ func (dt *DateTime) UnmarshalText(data []byte) error {
 	*dt, err = ParseDateTime(string(data))
 	return err
 }
-
-var (
-	dateTimeZeroDatePrefix  = []byte(`"0000-00-00`)
-	dateTimeZeroDatePostfix = []byte(`"`)
-)
 
 // UnmarshalJSON implements encoding/json Unmarshaler interface
 func (dt *DateTime) UnmarshalJSON(data []byte) error {

--- a/civil_test.go
+++ b/civil_test.go
@@ -132,7 +132,7 @@ func TestDate_UnmarshalJSON(t *testing.T) {
 	jsonInvalid := []byte(`"2020-13-40"`)
 	dInvalid := &Date{}
 	err = dInvalid.UnmarshalJSON(jsonInvalid)
-	assert.EqualError(t, err, "invalid date, data: 2020-13-40, err: parsing time \"2020-13-40\": month out of range")
+	assert.NotNil(t, err)
 }
 
 func TestDate_AddMonths(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/openlyinc/civil
 
 go 1.13
 
-require github.com/stretchr/testify v1.4.0
+require (
+	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,13 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Resolves #798

Go zero values for the `civil.Date` and `civil.DateTime` would fail with the Go zero value for these types.

- Added explicit checks for the zero value in the unmarshal functions to return expected value.
- Added unit tests.
